### PR TITLE
Fix details screen city info

### DIFF
--- a/KotlinApp/app/src/main/java/space/mairi/application_architecture/view/details/DetailsFragment.kt
+++ b/KotlinApp/app/src/main/java/space/mairi/application_architecture/view/details/DetailsFragment.kt
@@ -38,8 +38,9 @@ class DetailsFragment : Fragment() {
 
         val weather = arguments?.getParcelable<Weather>(BUNDLE_EXTRA)
 
-        if (weather != null){
-            binding.cityName.text = String.format(
+        if (weather != null) {
+            binding.cityName.text = weather.city.city
+            binding.cityCoordinates.text = String.format(
                 getString(R.string.city_coordinates),
                 weather.city.lat.toString(),
                 weather.city.lon.toString()


### PR DESCRIPTION
## Summary
- display city name and coordinates in the DetailsFragment

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68434c61ea588324b9421fc4c18b382f